### PR TITLE
enable input buttons to change metric value

### DIFF
--- a/src/components/DoExercise.jsx
+++ b/src/components/DoExercise.jsx
@@ -10,6 +10,8 @@ function DoExercise({
   tracker,
   setNumFinishedExercises,
   register,
+  setValue,
+  getValues,
 }) {
   const [activeKey, setActiveKey] = useState(1);
   const [isFinished, setIsFinished] = useState(false);
@@ -56,6 +58,8 @@ function DoExercise({
               setNumFinishedSets={setNumFinishedSets}
               register={register}
               exerciseId={exercise.id}
+              setValue={setValue}
+              getValues={getValues}
             />
           ))}
         </Accordion>

--- a/src/components/DoSet.jsx
+++ b/src/components/DoSet.jsx
@@ -19,6 +19,8 @@ function DoSet({
   setNumFinishedSets,
   register,
   exerciseId,
+  setValue,
+  getValues,
 }) {
   // const handleFinishWorkout = useFinishWorkout();
   const { dispatch } = useGlobalContext();
@@ -49,7 +51,13 @@ function DoSet({
         </span>
       </Accordion.Header>
       <Accordion.Body style={{ backgroundColor: "var(--bs-gray-200)" }}>
-        <SetBody set={set} register={register} exerciseId={exerciseId} />
+        <SetBody
+          set={set}
+          register={register}
+          exerciseId={exerciseId}
+          setValue={setValue}
+          getValues={getValues}
+        />
         {isNoteVisible && (
           <SetNote set={set} register={register} exerciseId={exerciseId} />
         )}

--- a/src/components/SetBody.jsx
+++ b/src/components/SetBody.jsx
@@ -4,8 +4,27 @@ import InputGroup from "react-bootstrap/InputGroup";
 import { BsPlusLg, BsDashLg } from "react-icons/bs";
 import { useGlobalContext } from "../context/GlobalContext";
 
-function SetBody({ set, register, exerciseId }) {
+function SetBody({ set, register, exerciseId, setValue, getValues }) {
   const { isWorkoutStarted } = useGlobalContext();
+  const weightFieldName = `exercise-${exerciseId}-weight-${set.id}`;
+  const repsFieldName = `exercise-${exerciseId}-reps-${set.id}`;
+
+  function incrementWeight() {
+    setValue(weightFieldName, getValues(weightFieldName) + 5);
+  }
+
+  function decrementWeight() {
+    setValue(weightFieldName, getValues(weightFieldName) - 5);
+  }
+
+  function incrementReps() {
+    setValue(repsFieldName, getValues(repsFieldName) + 1);
+  }
+
+  function decrementReps() {
+    setValue(repsFieldName, getValues(repsFieldName) - 1);
+  }
+
   return (
     <>
       {set.weight && (
@@ -16,6 +35,7 @@ function SetBody({ set, register, exerciseId }) {
               variant="secondary"
               id="button-minus-weight"
               disabled={!isWorkoutStarted}
+              onClick={decrementWeight}
               // how to decrement weight value?
             >
               <BsDashLg />
@@ -23,7 +43,7 @@ function SetBody({ set, register, exerciseId }) {
             <Form.Control
               className="text-center"
               type="number"
-              {...register(`exercise-${exerciseId}-weight-${set.id}`)}
+              {...register(weightFieldName)}
               // value={set.weight} // how to onChange value with react hook form?
               aria-label="Weight"
               disabled={!isWorkoutStarted}
@@ -32,6 +52,7 @@ function SetBody({ set, register, exerciseId }) {
               variant="secondary"
               id="button-plus-weight"
               disabled={!isWorkoutStarted}
+              onClick={incrementWeight}
             >
               <BsPlusLg />
             </Button>
@@ -44,12 +65,13 @@ function SetBody({ set, register, exerciseId }) {
           variant="secondary"
           id="button-minus-reps"
           disabled={!isWorkoutStarted}
+          onClick={decrementReps}
         >
           <BsDashLg />
         </Button>
         <Form.Control
           className="text-center"
-          {...register(`exercise-${exerciseId}-reps-${set.id}`)}
+          {...register(repsFieldName)}
           type="number"
           // value={set.reps}
           aria-label="reps"
@@ -59,6 +81,7 @@ function SetBody({ set, register, exerciseId }) {
           variant="secondary"
           id="button-plus-reps"
           disabled={!isWorkoutStarted}
+          onClick={incrementReps}
         >
           <BsPlusLg />
         </Button>

--- a/src/components/WorkoutAccordion.jsx
+++ b/src/components/WorkoutAccordion.jsx
@@ -7,6 +7,8 @@ function WorkoutAccordion({
   activeKey,
   setNumFinishedExercises,
   register,
+  setValue,
+  getValues,
 }) {
   return (
     <Accordion defaultActiveKey={`0`}>
@@ -19,6 +21,8 @@ function WorkoutAccordion({
           key={exercise.name}
           setNumFinishedExercises={setNumFinishedExercises}
           register={register}
+          setValue={setValue}
+          getValues={getValues}
         />
       ))}
     </Accordion>

--- a/src/pages/DoWorkout.jsx
+++ b/src/pages/DoWorkout.jsx
@@ -38,7 +38,7 @@ function DoWorkout() {
   const form = useForm({
     defaultValues: getDefaultValues(workout),
   });
-  const { register, control, handleSubmit } = form;
+  const { register, control, handleSubmit, setValue, getValues } = form;
 
   function handleBack() {
     dispatch({ type: "clear-workout" });
@@ -85,6 +85,8 @@ function DoWorkout() {
             activeKey={activeKey}
             setNumFinishedExercises={setNumFinishedExercises}
             register={register}
+            setValue={setValue}
+            getValues={getValues}
           />
         ) : (
           <WorkoutTable workout={workout} />


### PR DESCRIPTION
Fixes #27

enabled buttons to change input field value using React Hook Form, setValue() and getValues() methods.

Should probably move useForm() call and all subsequent methods to GlobalContext to avoid props drilling.