### PR TITLE
Lock up editing completed sets behind an `edit` button

### DIFF
--- a/src/components/DoExercise.jsx
+++ b/src/components/DoExercise.jsx
@@ -5,8 +5,6 @@ import { BsCheckSquareFill } from "react-icons/bs";
 
 function DoExercise({
   exercise,
-  numExercises,
-  index,
   tracker,
   setNumFinishedExercises,
   register,
@@ -17,7 +15,6 @@ function DoExercise({
   const [isFinished, setIsFinished] = useState(false);
   const [numFinishedSets, setNumFinishedSets] = useState(0);
   const numSets = exercise.sets.length;
-  const isLastExercise = numExercises === index + 1;
 
   function handleFinishSet() {
     setActiveKey((prev) => prev - 1);
@@ -53,7 +50,6 @@ function DoExercise({
               activeKey={activeKey}
               handleFinishSet={handleFinishSet}
               numSets={numSets}
-              isLastExercise={isLastExercise}
               checkExercise={checkExerciseFinished}
               setNumFinishedSets={setNumFinishedSets}
               register={register}

--- a/src/components/DoSet.jsx
+++ b/src/components/DoSet.jsx
@@ -14,7 +14,6 @@ function DoSet({
   index,
   activeKey,
   handleFinishSet,
-  isLastExercise,
   checkExercise,
   setNumFinishedSets,
   register,
@@ -26,8 +25,7 @@ function DoSet({
   const { dispatch } = useGlobalContext();
   const [isNoteVisible, setIsNoteVisible] = useState(false);
   const [isFinished, setIsFinished] = useState(false);
-
-  const isLastSetOfWorkout = index + 1 === numSets && isLastExercise;
+  const [isUnlocked, setIsUnlocked] = useState(false);
 
   function handleClick() {
     setIsFinished(true); // disables 'finish set' button
@@ -58,6 +56,7 @@ function DoSet({
           setValue={setValue}
           getValues={getValues}
           isFinished={isFinished}
+          isUnlocked={isUnlocked}
         />
         {isNoteVisible && (
           <SetNote
@@ -65,14 +64,16 @@ function DoSet({
             register={register}
             exerciseId={exerciseId}
             isFinished={isFinished}
+            isUnlocked={isUnlocked}
           />
         )}
         <SetButtons
           isNoteVisible={isNoteVisible}
           setIsNoteVisible={setIsNoteVisible}
           handleClick={handleClick}
-          isLastSetOfWorkout={isLastSetOfWorkout}
           isFinished={isFinished}
+          isUnlocked={isUnlocked}
+          setIsUnlocked={setIsUnlocked}
         />
       </Accordion.Body>
     </Accordion.Item>

--- a/src/components/SetBody.jsx
+++ b/src/components/SetBody.jsx
@@ -2,7 +2,6 @@ import Button from "react-bootstrap/Button";
 import Form from "react-bootstrap/Form";
 import InputGroup from "react-bootstrap/InputGroup";
 import { BsPlusLg, BsDashLg } from "react-icons/bs";
-import { useGlobalContext } from "../context/GlobalContext";
 
 function SetBody({
   set,
@@ -11,8 +10,8 @@ function SetBody({
   setValue,
   getValues,
   isFinished,
+  isUnlocked,
 }) {
-  const { isWorkoutStarted } = useGlobalContext();
   const weightFieldName = `exercise-${exerciseId}-weight-${set.id}`;
   const repsFieldName = `exercise-${exerciseId}-reps-${set.id}`;
 
@@ -41,7 +40,7 @@ function SetBody({
             <Button
               variant="secondary"
               id="button-minus-weight"
-              disabled={isFinished}
+              disabled={isFinished && !isUnlocked}
               onClick={decrementWeight}
               // how to decrement weight value?
             >
@@ -53,12 +52,12 @@ function SetBody({
               {...register(weightFieldName)}
               // value={set.weight} // how to onChange value with react hook form?
               aria-label="Weight"
-              disabled={isFinished}
+              disabled={isFinished && !isUnlocked}
             />
             <Button
               variant="secondary"
               id="button-plus-weight"
-              disabled={isFinished}
+              disabled={isFinished && !isUnlocked}
               onClick={incrementWeight}
             >
               <BsPlusLg />
@@ -71,7 +70,7 @@ function SetBody({
         <Button
           variant="secondary"
           id="button-minus-reps"
-          disabled={isFinished}
+          disabled={isFinished && !isUnlocked}
           onClick={decrementReps}
         >
           <BsDashLg />
@@ -80,14 +79,13 @@ function SetBody({
           className="text-center"
           {...register(repsFieldName)}
           type="number"
-          // value={set.reps}
           aria-label="reps"
-          disabled={isFinished}
+          disabled={isFinished && !isUnlocked}
         />
         <Button
           variant="secondary"
           id="button-plus-reps"
-          disabled={isFinished}
+          disabled={isFinished && !isUnlocked}
           onClick={incrementReps}
         >
           <BsPlusLg />

--- a/src/components/SetButtons.jsx
+++ b/src/components/SetButtons.jsx
@@ -1,15 +1,14 @@
 import { Button, Col, Row } from "react-bootstrap";
-import { BsStickyFill } from "react-icons/bs";
-import { useGlobalContext } from "../context/GlobalContext";
+import { BsStickyFill, BsLockFill, BsUnlockFill } from "react-icons/bs";
 
 function SetButtons({
   isNoteVisible,
   setIsNoteVisible,
   handleClick,
-  isLastSetOfWorkout,
   isFinished,
+  isUnlocked,
+  setIsUnlocked,
 }) {
-  const { isWorkoutStarted } = useGlobalContext();
   return (
     <Row className="mt-3">
       {!isNoteVisible && (
@@ -18,20 +17,38 @@ function SetButtons({
             variant="secondary"
             className=""
             onClick={() => setIsNoteVisible(true)}
-            disabled={!isWorkoutStarted || isFinished}
+            disabled={isFinished && !isUnlocked}
           >
             <BsStickyFill />
           </Button>
         </Col>
       )}
       <Col>
-        <Button
-          className="w-100"
-          onClick={handleClick}
-          disabled={!isWorkoutStarted || isFinished}
-        >
-          {isLastSetOfWorkout ? "Finish Set" : "Finish Set"}
-        </Button>
+        {!isFinished ? (
+          <Button className="w-100" onClick={handleClick}>
+            Finish Set
+          </Button>
+        ) : isUnlocked ? (
+          <Button
+            onClick={() => setIsUnlocked((prev) => !prev)}
+            className="w-100"
+            variant="primary"
+          >
+            <span>
+              <BsLockFill /> Save
+            </span>
+          </Button>
+        ) : (
+          <Button
+            onClick={() => setIsUnlocked((prev) => !prev)}
+            className="w-100"
+            variant="warning"
+          >
+            <span>
+              <BsUnlockFill /> Edit
+            </span>
+          </Button>
+        )}
       </Col>
     </Row>
   );

--- a/src/components/SetNote.jsx
+++ b/src/components/SetNote.jsx
@@ -1,13 +1,13 @@
 import { Form, InputGroup } from "react-bootstrap";
 
-function SetNote({ set, register, exerciseId, isFinished }) {
+function SetNote({ set, register, exerciseId, isFinished, isUnlocked }) {
   return (
     <InputGroup className="mt-3">
       <Form.Control
         as="textarea"
         placeholder="Notes"
         aria-label="With textarea"
-        disabled={isFinished}
+        disabled={isFinished && !isUnlocked}
         {...register(`exercise-${exerciseId}-note-${set.id}`)}
       />
     </InputGroup>

--- a/src/components/WorkoutAccordion.jsx
+++ b/src/components/WorkoutAccordion.jsx
@@ -3,7 +3,6 @@ import DoExercise from "./DoExercise";
 
 function WorkoutAccordion({
   workout,
-  numExercises,
   activeKey,
   setNumFinishedExercises,
   register,
@@ -15,7 +14,6 @@ function WorkoutAccordion({
       {workout.exercises.map((exercise, index) => (
         <DoExercise
           exercise={exercise}
-          numExercises={numExercises}
           index={index}
           tracker={index + activeKey}
           key={exercise.name}

--- a/src/pages/DoWorkout.jsx
+++ b/src/pages/DoWorkout.jsx
@@ -81,7 +81,6 @@ function DoWorkout() {
         {isWorkoutStarted ? (
           <WorkoutAccordion
             workout={workout}
-            numExercises={numExercises}
             activeKey={activeKey}
             setNumFinishedExercises={setNumFinishedExercises}
             register={register}


### PR DESCRIPTION
Fixes #20 add unlock feature to edit finished set data