### PR TITLE
fix edit set

### DIFF
--- a/src/context/GlobalContext.jsx
+++ b/src/context/GlobalContext.jsx
@@ -69,6 +69,11 @@ function reducer(state, action) {
         ...state,
         tempWorkoutData: [...state.tempWorkoutData, action.payload],
       };
+    case "edit-set-data":
+      return {
+        ...state,
+        tempWorkoutData: [...action.payload],
+      };
     default:
       throw new Error("unknown action type");
   }

--- a/src/features/workout/DoSet.jsx
+++ b/src/features/workout/DoSet.jsx
@@ -10,8 +10,6 @@ import SetBody from "./SetBody";
 import SetNote from "./SetNote";
 import SetButtons from "./SetButtons";
 
-// import { useFinishWorkout } from "../hooks/useFinishWorkout";
-
 function DoSet({
   set,
   numSets,
@@ -22,11 +20,11 @@ function DoSet({
   setNumFinishedSets,
   exercise,
 }) {
-  // const handleFinishWorkout = useFinishWorkout();
-  const { dispatch } = useGlobalContext();
+  const { dispatch, tempWorkoutData } = useGlobalContext();
   const [isNoteVisible, setIsNoteVisible] = useState(false);
   const [isFinished, setIsFinished] = useState(false);
   const [isUnlocked, setIsUnlocked] = useState(false);
+  const [isEditSet, setIsEditSet] = useState(false);
 
   const form = useForm({
     defaultValues: getSetDefaultValues(set),
@@ -43,8 +41,6 @@ function DoSet({
 
     const { note, ...metricsObject } = data;
 
-    console.log(metricsObject);
-
     const metrics = [];
 
     for (const property in metricsObject) {
@@ -53,6 +49,7 @@ function DoSet({
 
     console.log(metrics);
 
+    // put all metrics in a sub-object and separate out note. If no note, then note value is undefined
     const formatData = {
       exerciseId: exercise.id,
       exerciseName: exercise.name,
@@ -60,9 +57,19 @@ function DoSet({
       datetime: new Date(),
       note,
       metrics,
-      // put all metrics in a sub-object and separate out note. If no note, then note value is undefined
     };
-    dispatch({ type: "submit-set-data", payload: formatData });
+
+    // when editing set, create copy of tempWorkoutData with edited set having updated note and metrics data. Then dispatch to replace workoutData with this copy
+    const editedWorkoutData = tempWorkoutData.map((oldSet) =>
+      oldSet.setId === set.id ? { ...oldSet, note, metrics } : oldSet
+    );
+
+    if (isEditSet) {
+      dispatch({
+        type: "edit-set-data",
+        payload: editedWorkoutData,
+      });
+    } else dispatch({ type: "submit-set-data", payload: formatData });
   }
 
   return (
@@ -100,6 +107,7 @@ function DoSet({
             isFinished={isFinished}
             isUnlocked={isUnlocked}
             setIsUnlocked={setIsUnlocked}
+            setIsEditSet={setIsEditSet}
           />
         </form>
         <DevTool control={control} />

--- a/src/features/workout/SetButtons.jsx
+++ b/src/features/workout/SetButtons.jsx
@@ -7,6 +7,7 @@ function SetButtons({
   isFinished,
   isUnlocked,
   setIsUnlocked,
+  setIsEditSet,
 }) {
   return (
     <Row className="mt-3">
@@ -39,7 +40,11 @@ function SetButtons({
           </Button>
         ) : (
           <Button
-            onClick={() => setIsUnlocked((prev) => !prev)}
+            onClick={() => {
+              setIsUnlocked((prev) => !prev);
+              setIsEditSet(true);
+            }}
+            type="submit"
             className="w-100"
             variant="warning"
           >


### PR DESCRIPTION
Fixes #37

Use `isEditSet` flag so when submitting data with 'edit' button, it's dispatched differently.

When editing a set, handleSubmitSet() makes a copy of `tempWorkoutData` and replaces note and metrics of edited set. Then this copy is dispatched to replace `tempWorkoutData`