### PR TITLE
Disable click on future set accordion items

### DIFF
--- a/src/features/workout/DoExercise.jsx
+++ b/src/features/workout/DoExercise.jsx
@@ -46,6 +46,7 @@ function DoExercise({ exercise, tracker, setNumFinishedExercises }) {
               checkExercise={checkExerciseFinished}
               setNumFinishedSets={setNumFinishedSets}
               exercise={exercise}
+              canToggle={i <= numFinishedSets}
             />
           ))}
         </Accordion>

--- a/src/features/workout/DoSet.jsx
+++ b/src/features/workout/DoSet.jsx
@@ -18,6 +18,7 @@ function DoSet({
   checkExercise,
   setNumFinishedSets,
   exercise,
+  canToggle,
 }) {
   const { dispatch, tempWorkoutData } = useGlobalContext();
   const [isNoteVisible, setIsNoteVisible] = useState(false);
@@ -37,14 +38,6 @@ function DoSet({
     if (index + 1 === numSets) dispatch({ type: "next-exercise" }); // if last set for exercise then go to next exercise
 
     const { note, ...metrics } = data;
-
-    /* const metrics = [];
-
-    for (const property in metricsObject) {
-      metrics.push({ name: property, value: metricsObject[property] });
-    } */
-
-    // put all metrics in a sub-object and separate out note. If no note, then note value is undefined
     const formatData = {
       exerciseId: exercise.exerciseIndex,
       exerciseName: exercise.name,
@@ -69,9 +62,13 @@ function DoSet({
 
   return (
     <Accordion.Item eventKey={`${index - 1 + activeKey}`}>
-      <Accordion.Header>
+      <Accordion.Header style={canToggle ? {} : { pointerEvents: "none" }}>
         <span className="d-flex justify-content-between w-100 px-1">
-          <span className={isFinished ? "text-secondary" : "fw-bold "}>
+          <span
+            className={
+              isFinished ? "text-secondary" : canToggle ? "fw-bold" : ""
+            }
+          >
             {isFinished && (
               <BsCheckSquareFill style={{ color: "var(--bs-blue)" }} />
             )}{" "}


### PR DESCRIPTION
Fixes #64

Disable click on future set accordion items. Use a `canToggle` is true if index <= `numFinishedSets`

Also use this to only have active accordion header in bold. Future items are not bold.