### PR TITLE
Clicking note button should focus into note field

### DIFF
--- a/src/features/workout/SetNote.jsx
+++ b/src/features/workout/SetNote.jsx
@@ -11,6 +11,7 @@ function SetNote({
       <Form.Control
         id="note"
         as="textarea"
+        autoFocus
         placeholder="Write notes here..."
         aria-label="With textarea"
         disabled={isFinished && !isUnlocked}


### PR DESCRIPTION
Fixes #69

Just needed to add `autoFocus` prop to `SetNote` form field. 

That was easy.